### PR TITLE
feat(docs): add sdk documentation

### DIFF
--- a/apps/docs/mint.json
+++ b/apps/docs/mint.json
@@ -64,6 +64,21 @@
                     ]
                 }
             ]
+        },
+        {
+            "group": "@unkey/api SDK",
+            "icon": "code",
+            "pages": [
+                "sdk/get-started",
+                {
+                    "group": "Keys",
+                    "pages": [
+                        "sdk/keys/create",
+                        "sdk/keys/verify",
+                        "sdk/keys/revoke"
+                    ]
+                }
+            ]
         }
     ],
     "footerSocials": {

--- a/apps/docs/sdk/get-started.mdx
+++ b/apps/docs/sdk/get-started.mdx
@@ -1,0 +1,43 @@
+---
+title: "Overview"
+description: "Typescript client for unkey"
+---
+
+
+If you prefer a typed experience over calling http endpoints directly, you can use our sdk `@unkey/api`.
+
+
+## Install
+
+<Tabs>
+  <Tab title="pnpm">
+    ```bash
+    pnpm add @unkey/api
+    ```
+  </Tab>
+  <Tab title="yarn">
+    ```bash
+    yarn add @unkey/api
+    ```
+  </Tab>
+  <Tab title="npm">
+    ```bash
+    npm install @unkey/api
+    ```
+  </Tab>
+</Tabs>
+
+
+
+## Bearer Token
+
+When requesting resources, you will need your access token — you can create a new one in the [settings](https://unkey.dev/app/keys).
+Afterwards you need to provide it to the client:
+
+```ts 
+import { Unkey } from "@unkey/api"
+
+const unkey = new Unkey({token: "<UNKEY_TOKEN>" })
+```
+
+Always keep your token safe and reset it if you suspect it has been compromised.

--- a/apps/docs/sdk/keys/create.mdx
+++ b/apps/docs/sdk/keys/create.mdx
@@ -1,0 +1,132 @@
+---
+title: "Create"
+description: "Create an api key for your users"
+---
+
+## Request
+
+<ParamField body="apiId" type="string" required>
+Choose an `API` where this key should be created.
+</ParamField>
+
+
+<ParamField body="prefix" type="string" >
+To make it easier for your users to understand which product an api key belongs to, you can add prefix them.
+
+For example Stripe famously prefixes their customer ids with `cus_` or their api keys with `sk_live_`.
+
+The underscore is automtically added if you are defining a prefix, for example: `"prefix": "abc"` will result in a key like `abc_xxxxxxxxx`
+
+</ParamField>
+
+
+<ParamField body="byteLength" type="int" default={16} >
+The bytelength used to generate your key determines its entropy as well as its length.
+Higher is better, but keys become longer and more annoying to handle.
+
+The default is `16 bytes`, or 2<sup>128</sup> possible combinations
+ </ParamField>
+
+
+ <ParamField body="ownerId" type="string" >
+  Your user's Id. This will provide a link between Unkey and your customer record.
+
+  When validating a key, we will return this back to you, so you can clearly identify your user from their api key.
+
+</ParamField>
+
+<ParamField body="meta" type="object" >
+This is a place for dynamic meta data, anything that feels useful for you should go here
+
+Example:
+```json
+{
+  "billingTier":"PRO",
+  "trialEnds": "2023-06-16T17:16:37.161Z"
+}
+```
+
+</ParamField>
+<ParamField body="expires" type="int" >
+  You can auto expire keys by providing a unix timestamp in milliseconds.
+
+  Once keys expire they will automatically be deleted and are no longer valid.
+
+
+</ParamField>
+
+<ParamField body="ratelimit" type="Object" >
+
+ Unkey comes with per-key ratelimiting out of the box.
+
+  <Expandable title="properties">
+
+  <ParamField body="type" type="string" default="fast" required>
+  Either `fast` or `consistent`.
+
+  Read more [here](/features/ratelimiting)
+
+  </ParamField>
+  <ParamField body="limit" type="int" required>
+  The total amount of burstable requests.
+
+
+  </ParamField>
+  <ParamField body="refillRate" type="int" required>
+  How many tokens to refill during each `refillInterval`
+  </ParamField>
+  <ParamField body="refillInterval" type="int" required>
+  Determines the speed at which tokens are refilled.
+
+  In milliseconds
+  </ParamField>
+ </Expandable>
+</ParamField>
+
+## Response
+
+<ResponseField name="key" type="string" required>
+  The newly created api key
+</ResponseField>
+
+<RequestExample>
+
+
+
+```ts
+const created = await unkey.keys.create({
+	apiId:"api_7oKUUscTZy22jmVf9THxDA",
+	prefix:"xyz",
+	byteLength:16,
+	ownerId:"chronark",
+	meta:{
+		hello: "world"
+	},
+	expires: 1686941966471,
+	ratelimit:{
+		type:"fast",
+		limit:10,
+		refillRate: 1,
+		refillInterval: 1000
+	}
+})
+
+console.log(created.key)
+
+```
+
+
+
+
+
+</RequestExample>
+
+<ResponseExample>
+```json
+{
+	"key": "xyz_AS5HDkXXPot2MMoPHD8jnL"
+}
+```
+
+
+</ResponseExample>

--- a/apps/docs/sdk/keys/revoke.mdx
+++ b/apps/docs/sdk/keys/revoke.mdx
@@ -1,0 +1,27 @@
+---
+title: "Revoke"
+description: "Delete an api key for your users"
+---
+
+## Request
+
+<ParamField path="keyId" type="string" required>
+The ID of the key you want to revoke.
+</ParamField>
+
+
+## Response
+
+No response, but if it didn't throw an error, you're good.
+
+<RequestExample>
+
+
+
+```ts
+await unkey.keys.revoke({keyId: "key_123"})
+```
+
+
+
+</RequestExample>

--- a/apps/docs/sdk/keys/verify.mdx
+++ b/apps/docs/sdk/keys/verify.mdx
@@ -1,0 +1,66 @@
+---
+title: "Verify"
+description: "Verify a key"
+---
+
+Verify a key from your users.
+
+## Request
+
+<ParamField body="key" type="string" required>
+The key you want to verify.
+</ParamField>
+
+## Response
+
+<ResponseField name="valid" type="boolean" required>
+  Whether or not this key is valid and has passed the ratelimit.
+  If `false` you should not grant access to whatever the user is requesting
+</ResponseField>
+<ResponseField name="ownerId" type="string">
+  If you have set an `ownerId` on this key it is returned here. You can use this to clearly authenticate a user in your system.
+</ResponseField>
+
+
+<ResponseField name="meta" type="object" >
+This is the `meta` data you have set when creating the key.
+
+Example:
+```json
+{
+  "billingTier":"PRO",
+  "trialEnds": "2023-06-16T17:16:37.161Z"
+}
+```
+
+</ResponseField>
+
+<RequestExample>
+
+
+
+```ts
+const res = await unkey.keys.verify({
+  key: "xyz_AS5HDkXXPot2MMoPHD8jnL"
+})
+```
+
+
+
+
+
+</RequestExample>
+
+<ResponseExample>
+```ts
+{
+	valid: true,
+	ownerId: "chronark",
+	meta: {
+		hello: "world"
+	}
+}
+```
+
+
+</ResponseExample>


### PR DESCRIPTION
Add documentation for the `@unkey/api` SDK, including a `get-started` page and pages for creating, revoking, and verifying keys.
