### PR TITLE
Update api reference example responses

### DIFF
--- a/apps/docs/api-reference/apis/list-keys.mdx
+++ b/apps/docs/api-reference/apis/list-keys.mdx
@@ -156,7 +156,7 @@ curl \
       "apiId": "api_QUGih1EMtBy9eSSf3vujmF",
       "workspaceId": "ws_o17fS1LvwtRswPdncAcUM",
       "start": "key_Crg",
-      "createdAt": "2023-06-21T18:26:07.058Z",
+      "createdAt": 1687642066782,
       "expires": null,
       "ratelimit": {
         "type": "fast",

--- a/apps/docs/api-reference/keys/create.mdx
+++ b/apps/docs/api-reference/keys/create.mdx
@@ -18,13 +18,13 @@ To make it easier for your users to understand which product an api key belongs 
 
 For example Stripe famously prefixes their customer ids with `cus_` or their api keys with `sk_live_`.
 
-The underscore is automtically added if you are defining a prefix, for example: `"prefix": "abc"` will result in a key like `abc_xxxxxxxxx`
+The underscore is automatically added if you are defining a prefix, for example: `"prefix": "abc"` will result in a key like `abc_xxxxxxxxx`
 
 </ParamField>
 
 
 <ParamField body="byteLength" type="int" default={16} >
-The bytelength used to generate your key determines its entropy as well as its length.
+The byte length used to generate your key determines its entropy as well as its length.
 Higher is better, but keys become longer and more annoying to handle.
 
 The default is `16 bytes`, or 2<sup>128</sup> possible combinations
@@ -102,22 +102,21 @@ curl --request POST \
   --header 'Authorization: Bearer <UNKEY>' \
   --header 'Content-Type: application/json' \
   --data '{
-	"apiId":"api_7oKUUscTZy22jmVf9THxDA",
-	"prefix":"xyz",
-	"byteLength":16,
-	"ownerId":"chronark",
-	"meta":{
-		"hello": "world"
-	},
-	"expires": 1686941966471,
-	"ratelimit":{
-		"type":"fast",
-		"limit":10,
-		"refillRate": 1,
-		"refillInterval": 1000
-	}
-
-}'
+    "apiId":"api_7oKUUscTZy22jmVf9THxDA",
+    "prefix":"xyz",
+    "byteLength":16,
+    "ownerId":"chronark",
+    "meta":{
+      "hello": "world"
+    },
+    "expires": 1686941966471,
+    "ratelimit":{
+      "type":"fast",
+      "limit":10,
+      "refillRate": 1,
+      "refillInterval": 1000
+    }
+  }'
 ```
 
 
@@ -129,7 +128,8 @@ curl --request POST \
 <ResponseExample>
 ```json
 {
-	"key": "xyz_AS5HDkXXPot2MMoPHD8jnL"
+  "keyId": "key_cm9vdCBvZiBnb29kXa",
+  "key": "xyz_AS5HDkXXPot2MMoPHD8jnL"
 }
 ```
 

--- a/apps/docs/api-reference/keys/verify.mdx
+++ b/apps/docs/api-reference/keys/verify.mdx
@@ -46,8 +46,8 @@ curl --request POST \
   --url https://api.unkey.dev/v1/keys/verify \
   --header 'Content-Type: application/json' \
   --data '{
-	"key":"xyz_AS5HDkXXPot2MMoPHD8jnL"
-}'
+    "key":"xyz_AS5HDkXXPot2MMoPHD8jnL"
+  }'
 ```
 
 


### PR DESCRIPTION
This PR updates a few things:

- `keyId` was missing from Create Key example response
- `createdAt` was an ISO format date string instead of unix epoch for List Keys example response
- typo/grammar fixes
- inconsistent use of tabs and spaces
