### PR TITLE
Add Elixir Documentation to the Unkey site

### DIFF
--- a/apps/docs/libraries/ex/functions/create_key.mdx
+++ b/apps/docs/libraries/ex/functions/create_key.mdx
@@ -1,0 +1,141 @@
+---
+title: "create_key"
+description: "Create an api key for your users"
+---
+
+> @spec create_key(map) :: map()
+
+Creates an API key for your users.
+
+## Request
+
+<ParamField body="apiId" type="string" required>
+  Choose an `API` where this key should be created.
+</ParamField>
+
+<ParamField body="prefix" type="string" >
+To make it easier for your users to understand which product an api key belongs to, you can add prefix them.
+
+For example Stripe famously prefixes their customer ids with `cus_` or their api keys with `sk_live_`.
+
+The underscore is automtically added if you are defining a prefix, for example: `"prefix": "abc"` will result in a key like `abc_xxxxxxxxx`
+
+</ParamField>
+
+<ParamField body="byteLength" type="int" default={16} >
+The bytelength used to generate your key determines its entropy as well as its length.
+Higher is better, but keys become longer and more annoying to handle.
+
+The default is `16 bytes`, or 2<sup>128</sup> possible combinations
+
+ </ParamField>
+
+ <ParamField body="ownerId" type="string" >
+  Your user's Id. This will provide a link between Unkey and your customer record.
+
+When validating a key, we will return this back to you, so you can clearly identify your user from their api key.
+
+</ParamField>
+
+<ParamField body="meta" type="object" >
+This is a place for dynamic meta data, anything that feels useful for you should go here
+
+Example:
+
+```json
+{
+  "billingTier": "PRO",
+  "trialEnds": "2023-06-16T17:16:37.161Z"
+}
+```
+
+</ParamField>
+<ParamField body="expires" type="int" >
+  You can auto expire keys by providing a unix timestamp in milliseconds.
+
+Once keys expire they will automatically be deleted and are no longer valid.
+
+</ParamField>
+
+<ParamField body="ratelimit" type="Object" >
+
+Unkey comes with per-key ratelimiting out of the box.
+
+  <Expandable title="properties">
+
+  <ParamField body="type" type="string" default="fast" required>
+  Either `fast` or `consistent`.
+
+Read more [here](/features/ratelimiting)
+
+  </ParamField>
+  <ParamField body="limit" type="int" required>
+  The total amount of burstable requests.
+
+  </ParamField>
+  <ParamField body="refillRate" type="int" required>
+  How many tokens to refill during each `refillInterval`
+  </ParamField>
+  <ParamField body="refillInterval" type="int" required>
+  Determines the speed at which tokens are refilled.
+
+In milliseconds
+
+  </ParamField>
+ </Expandable>
+</ParamField>
+
+## Response
+
+<ResponseField name="key" type="string" required>
+  The newly created api key
+</ResponseField>
+
+<ResponseField name="keyId" type="string" required>
+  A unique id to reference this key for updating or revoking. This id can not be
+  used to verify the key.
+</ResponseField>
+
+<RequestExample>
+
+```elixir
+   try do
+        expiry =
+          DateTime.utc_now()
+          |> DateTime.add(100_000)
+          |> DateTime.to_unix(:millisecond)
+
+        opts =
+          UnkeyElixirSdk.create_key(%{
+            "apiId" => "api_7oKUUscTZy22jmVf9THxDA",
+            "prefix" => "xyz",
+            "byteLength" => 16,
+            "ownerId" => "glamboyosa",
+            "meta" => %{"hello" => "world"},
+            "expires" => expiry,
+            "ratelimit" => %{
+              "type" => "fast",
+              "limit" => 10,
+              "refillRate" => 1,
+              "refillInterval" => 1000
+            }
+          })
+
+        Logger.info(opts)
+      catch
+        err ->
+          Logger.error(err)
+      end
+```
+
+</RequestExample>
+
+<ResponseExample>
+```json
+{
+	"key": "xyz_AS5HDkXXPot2MMoPHD8jnL",
+     "keyId": "key_cm9vdCBvZiBnb29kXa",
+}
+```
+
+</ResponseExample>

--- a/apps/docs/libraries/ex/functions/revoke_key.mdx
+++ b/apps/docs/libraries/ex/functions/revoke_key.mdx
@@ -1,0 +1,42 @@
+---
+title: "revoke_key"
+description: "revoke a key"
+---
+
+> @spec revoke_key(binary) :: :ok
+
+Delete an api key for your users
+
+Returns `:ok`
+
+## Request
+
+<ParamField path="keyId" type="string" required>
+  The ID of the key you want to revoke.
+</ParamField>
+
+## Response
+
+Returns an atom `:ok`
+
+<RequestExample>
+
+```elixir
+   try do
+     :ok = UnkeyElixirSdk.revoke_key("xyz_AS5HDkXXPot2MMoPHD8jnL")
+
+    catch
+        err ->
+          Logger.error(err)
+      end
+```
+
+</RequestExample>
+
+<ResponseExample>
+
+```elixir
+:ok
+```
+
+</ResponseExample>

--- a/apps/docs/libraries/ex/functions/verify_key.mdx
+++ b/apps/docs/libraries/ex/functions/verify_key.mdx
@@ -1,0 +1,66 @@
+---
+title: "verify_key"
+description: "Verify a key"
+---
+
+> @spec verify_key(binary) :: map()
+
+Verify a key from your users. You only need to send the api key from your user.
+
+## Request
+
+<ParamField body="key" type="string" required>
+  The key you want to verify.
+</ParamField>
+
+## Response
+
+<ResponseField name="valid" type="boolean" required>
+  Whether or not this key is valid and has passed the ratelimit. If `false` you
+  should not grant access to whatever the user is requesting
+</ResponseField>
+<ResponseField name="ownerId" type="string">
+  If you have set an `ownerId` on this key it is returned here. You can use this
+  to clearly authenticate a user in your system.
+</ResponseField>
+
+<ResponseField name="meta" type="object" >
+This is the `meta` data you have set when creating the key.
+
+Example:
+
+```json
+{
+  "billingTier": "PRO",
+  "trialEnds": "2023-06-16T17:16:37.161Z"
+}
+```
+
+</ResponseField>
+
+<RequestExample>
+
+```elixir
+   try do
+     is_verified = UnkeyElixirSdk.verify_key("xyz_AS5HDkXXPot2MMoPHD8jnL")
+
+    catch
+        err ->
+          Logger.error(err)
+      end
+```
+
+</RequestExample>
+
+<ResponseExample>
+```ts
+{
+	valid: true,
+	ownerId: "glamboyosa",
+	meta: {
+		hello: "world"
+	}
+}
+```
+
+</ResponseExample>

--- a/apps/docs/libraries/ex/overview.mdx
+++ b/apps/docs/libraries/ex/overview.mdx
@@ -3,8 +3,51 @@ title: "Overview"
 description: "Elixir client for unkey"
 ---
 
-<Info>
-Coming Soon..
+[Elixir SDK](https://github.com/glamboyosa/unkey-elixir-sdk) for interacting with the platform programatically.
 
-[#48](https://github.com/chronark/unkey/issues/48)
-</Info>
+## Installation
+
+The package can be installed from Hex PM by adding `unkey_elixir_sdk` to your list of dependencies in `mix.exs`:
+
+> Note: This project uses Elixir version `1.13`.
+
+```elixir
+def deps do
+  [
+    {:unkey_elixir_sdk, "~> 0.1.0"}
+  ]
+end
+```
+
+## Start the GenServer
+
+In order to start this package we can either start it under a supervision tree (most common).
+
+The GenServer takes a map with two properties.
+
+- token: Your [Unkey](https://unkey.dev) Access token used to make requests. You can create one [here](https://unkey.dev/app/keys) **required**
+- base_url: The base URL endpoint you will be hitting i.e. `https://api.unkey.dev/v1/keys` (optional).
+
+```elixir
+children = [
+
+  %{
+    id: UnkeyElixirSdk,
+    start: {UnkeyElixirSdk, :start_link, [%{token: "yourunkeyapitoken"}]}
+  }
+]
+
+
+# Now we start the supervisor with the children and a strategy
+{:ok, pid} = Supervisor.start_link(children, strategy: :one_for_one)
+
+# After started, we can query the supervisor for information
+Supervisor.count_children(pid)
+#=> %{active: 1, specs: 1, supervisors: 0, workers: 1}
+```
+
+You can also call the `start_link` function instead.
+
+```elixir
+{:ok, _pid} = UnkeyElixirSdk.start_link(%{token: "yourunkeyapitoken", base_url: "https://api.unkey.dev/v1/keys"})
+```

--- a/apps/docs/mint.json
+++ b/apps/docs/mint.json
@@ -54,19 +54,12 @@
   "navigation": [
     {
       "group": "Get Started",
-      "pages": [
-        "introduction",
-        "quickstart",
-        "security"
-      ]
+      "pages": ["introduction", "quickstart", "security"]
     },
     {
       "group": "Features",
       "icon": "bolt",
-      "pages": [
-        "features/ratelimiting",
-        "features/temp-keys"
-      ]
+      "pages": ["features/ratelimiting", "features/temp-keys"]
     },
     {
       "group": "API Documentation",
@@ -83,10 +76,7 @@
         },
         {
           "group": "APIs",
-          "pages": [
-            "api-reference/apis/get",
-            "api-reference/apis/list-keys"
-          ]
+          "pages": ["api-reference/apis/get", "api-reference/apis/list-keys"]
         }
       ]
     },
@@ -108,15 +98,21 @@
     {
       "group": "Python",
       "icon": "code",
-      "pages": [
-        "libraries/py/overview"
-      ]
+      "pages": ["libraries/py/overview"]
     },
     {
       "group": "Elixir",
       "icon": "code",
       "pages": [
-        "libraries/ex/overview"
+        "libraries/ex/overview",
+        {
+          "group": "Functions",
+          "pages": [
+            "libraries/ex/functions/create_key",
+            "libraries/ex/functions/verify_key",
+            "libraries/ex/functions/revoke_key"
+          ]
+        }
       ]
     }
   ],


### PR DESCRIPTION
## Closes 
Closes #48 

## Description 

This PR adds Elixir documentation to the Unkey site for the #48. 

 ## Testing Plan 
 - [ ] Go to the docs site 
 - [ ] Go to the libraries section 
 - [ ] Under the Elixir section there should be overview docs which includes a brief overview. 
 - [ ] Go to the functions subdir, it should include all the Elixir SDK methods (can be corroborated with the [Hexdocs](https://hexdocs.pm/unkey_elixir_sdk/UnkeyElixirSdk.html) )