### PR TITLE
Add python sdk to docs

### DIFF
--- a/apps/docs/libraries/py/overview.mdx
+++ b/apps/docs/libraries/py/overview.mdx
@@ -3,7 +3,71 @@ title: "Overview"
 description: "Python client for unkey"
 ---
 
-<Info>
-Coming Soon..
+# unkey.py
 
-</Info>
+An asynchronous Python SDK for accessing the Unkey API.
+
+## Installation
+
+**Python version 3.8 or greater is required to use unkey.py.**
+
+### Stable
+
+```sh
+pip install -U unkey.py
+```
+
+### Development
+
+```sh
+pip install -U git+https://github.com/Jonxslays/unkey.py
+```
+
+For more information on using `pip`, check out the [pip documentation](https://pip.pypa.io/en/stable/).
+
+## Example
+
+Verifying an api key:
+
+```py
+import asyncio
+import os
+
+import unkey
+
+
+async def main() -> None:
+    client = unkey.Client(api_key=os.environ["API_KEY"])
+    await client.start()
+
+    result = await client.keys.verify_key("prefix_123ABC")
+
+    if result.is_ok:
+        data = result.unwrap()
+        print(data.valid)
+        print(data.owner_id)
+        print(data.meta)
+        print(data.error)
+    else:
+        print(result.unwrap_err())
+
+    await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+```
+
+## Guides
+
+- [Installation](https://jonxslays.github.io/unkey.py/stable/getting-started/installation/)
+- [Using the Client](https://jonxslays.github.io/unkey.py/stable/getting-started/client/)
+- [The Result type](https://jonxslays.github.io/unkey.py/stable/getting-started/result/)
+- [Contributing](https://jonxslays.github.io/unkey.py/stable/contributing/)
+
+## Other Links
+
+- [Stable Release Docs](https://jonxslays.github.io/unkey.py/)
+- [Development Branch Docs](https://jonxslays.github.io/unkey.py/dev/)
+- [Repository](https://github.com/Jonxslays/unkey.py)

--- a/apps/docs/libraries/py/services/apis.mdx
+++ b/apps/docs/libraries/py/services/apis.mdx
@@ -1,0 +1,32 @@
+---
+title: "ApiService"
+description: "The service used to make api related requests."
+---
+
+Available via the `apis` property of the `Client`.
+
+See the [full docs](https://jonxslays.github.io/unkey.py/stable/reference/services/#unkey.services.ApiService)
+on the `KeyService`.
+
+## Get api
+
+Gets an api with the given ID.
+
+```py
+result = await client.apis.get_api("api_123")
+```
+
+## List keys
+
+Retrieve a paginated list of api keys for a given api ID.
+
+```py
+# retrieve the first 100 api keys for this api
+result = await client.apis.list_keys("api_123")
+
+# retrieve the second 100 keys for this api
+result = await client.apis.list_keys("api_123", offset=100)
+
+# retrieve the second 10 api keys
+result = await client.apis.list_keys("api_123", offset=10, limit=10)
+```

--- a/apps/docs/libraries/py/services/keys.mdx
+++ b/apps/docs/libraries/py/services/keys.mdx
@@ -1,0 +1,35 @@
+---
+title: "KeyService"
+description: "The service used to make key related requests."
+---
+
+Available via the `keys` property of the `Client`.
+
+See the [full docs](https://jonxslays.github.io/unkey.py/stable/reference/services/#unkey.services.KeyService)
+on the `KeyService`.
+
+## Create key
+
+Creates a new API key for the api with the given ID.
+
+```py
+result = await client.keys.create_key(
+    "api_123", owner_id="jonxslays", prefix="test"
+)
+```
+
+## Verify key
+
+Verifies that a key is valid, and within ratelimit.
+
+```py
+result = await client.keys.verify_key("test_123DEF")
+```
+
+## Revoke key
+
+Revokes access and removes the key with the given ID.
+
+```py
+result = await client.keys.revoke_key("key_456GHI")
+```

--- a/apps/docs/mint.json
+++ b/apps/docs/mint.json
@@ -98,7 +98,13 @@
     {
       "group": "Python",
       "icon": "code",
-      "pages": ["libraries/py/overview"]
+      "pages": [
+        "libraries/py/overview",
+        {
+          "group": "Services",
+          "pages": ["libraries/py/services/keys", "libraries/py/services/apis"]
+        }
+      ]
     },
     {
       "group": "Elixir",


### PR DESCRIPTION
This PR adds documentation for the Python SDK.

Tried to keep it brief with an example for each method and other helpful links.
All methods and parameters are documented in depth in the API reference of the [unkey.py docs](https://jonxslays.github.io/unkey.py).
