### PR TITLE
chore: add missing playground dependency

### DIFF
--- a/packages/nuxt/playground/package.json
+++ b/packages/nuxt/playground/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@unkey/nuxt": "latest",
+    "@nuxt/devtools": "latest",
     "nuxt": "latest"
   }
 }


### PR DESCRIPTION
with this, we should be able to circulate this stackblitz for runnable nuxt+unkey starter:

https://stackblitz.com/github/chronark/unkey/tree/main/packages/nuxt/playground